### PR TITLE
fix a DB migration corner case

### DIFF
--- a/pkg/coredata/migrations/20250805T123605Z.sql
+++ b/pkg/coredata/migrations/20250805T123605Z.sql
@@ -1,4 +1,23 @@
+-- First, update rows where created_at is null but sent_at is not null
 UPDATE emails
 SET created_at = sent_at,
     updated_at = sent_at
-WHERE created_at < '2000-01-01';
+WHERE created_at IS NULL AND sent_at IS NOT NULL;
+
+-- Then, update rows where both created_at and sent_at are null
+UPDATE emails
+SET created_at = CURRENT_TIMESTAMP,
+    updated_at = CURRENT_TIMESTAMP
+WHERE created_at IS NULL AND sent_at IS NULL;
+
+-- Finally, update rows where created_at is very old (before 2000)
+UPDATE emails
+SET created_at = sent_at,
+    updated_at = sent_at
+WHERE created_at < '2000-01-01' AND sent_at IS NOT NULL;
+
+-- For very old rows where sent_at is also null, set to current timestamp
+UPDATE emails
+SET created_at = CURRENT_TIMESTAMP,
+    updated_at = CURRENT_TIMESTAMP
+WHERE created_at < '2000-01-01' AND sent_at IS NULL;


### PR DESCRIPTION
…trying to set created_at = sent_at but failed when sent_at was also null.

Adding proper null handling: The updated migration now: First updates rows where created_at is null but sent_at is not null Then handles rows where both created_at and sent_at are null by setting them to CURRENT_TIMESTAMP Finally handles the original case of very old dates (before 2000) Ensuring data integrity: All rows now have valid created_at and updated_at values, which allows the NOT NULL constraints to be applied successfully.
