### PR TITLE
fix: configure OpenTelemetry HTTP traces export to Tempo

### DIFF
--- a/cfg/kaamel.yaml
+++ b/cfg/kaamel.yaml
@@ -1,5 +1,15 @@
 # Probo Configuration Template
 # contains configuration options with some default values.
+unit:
+  metrics:
+    addr: "localhost:8081"
+  tracing:
+    addr: "localhost:4318"
+    max-batch-size: 512
+    batch-timeout: 5
+    export-timeout: 30
+    max-queue-size: 2048
+
 probod:
   hostname: "8vlq3we8mbakad4k.app.eng.kaamel.com"
   api:

--- a/compose.yaml
+++ b/compose.yaml
@@ -71,6 +71,7 @@ services:
       - "-config.file=/etc/tempo.yaml"
     ports:
       - "4317:4317"
+      - "4318:4318"
     volumes:
       - "./compose/tempo/tempo.yaml:/etc/tempo.yaml:ro"
       - "tempo-data:/var/tempo:rw"

--- a/compose/tempo/tempo.yaml
+++ b/compose/tempo/tempo.yaml
@@ -7,6 +7,8 @@ distributor:
       protocols:
         grpc:
           endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
 
 ingester:
   trace_idle_period: "10s"


### PR DESCRIPTION
- Add HTTP protocol support on port 4318 in Tempo config
- Update probod to use localhost:4318 for traces export
- Fix URL encoding and port conflict issues

Fixes OpenTelemetry traces export errors to Tempo collector.
